### PR TITLE
Moved from `click.echo()` to in-built logging library

### DIFF
--- a/protop2g/conf/standard.py
+++ b/protop2g/conf/standard.py
@@ -21,6 +21,10 @@ License and may only be used or replicated with the express permission
 of Red Hat, Inc.
 """
 
+
+from logging import getLogger
+from logging.config import dictConfig
+
 """
 STANDARD CONFIGURATION VARIABLES
 """
@@ -203,3 +207,31 @@ _This comment was originally created [here]({cmtslink}) by [**{cmtsauth}**]({cmt
 _This comment was automatically created by the
 [**Pagure2GitLab Importer Service**](https://github.com/gridhead/protop2g)._
 """
+
+# The default configuration for service logging
+logrconf = {
+    "version": 1,
+    "disable_existing_loggers": False,
+    "formatters": {
+        "standard": {
+            "format": "%(asctime)s %(message)s",
+            "datefmt": "[%Y-%m-%d %I:%M:%S %z]",
+        },
+    },
+    "handlers": {
+        "console": {
+            "level": "INFO",
+            "formatter": "standard",
+            "class": "logging.StreamHandler",
+            "stream": "ext://sys.stdout",
+        },
+    },
+    "root": {
+        "level": "INFO",
+        "handlers": ["console"],
+    },
+}
+
+dictConfig(logrconf)
+
+logger = getLogger(__name__)

--- a/protop2g/view/dcrt.py
+++ b/protop2g/view/dcrt.py
@@ -22,7 +22,9 @@ of Red Hat, Inc.
 """
 
 
-from click import echo, style
+from click import style
+
+from protop2g.conf.standard import logger
 
 PASS = style("[ PASS ]", fg="green", bold=True)
 FAIL = style("[ FAIL ]", fg="red", bold=True)
@@ -32,20 +34,20 @@ STDS = "        "
 
 
 def success(message):
-    echo(PASS + " " + style(message, fg="green", bold=True))
+    logger.info(PASS + " " + style(message, fg="green", bold=True))
 
 
 def failure(message):
-    echo(FAIL + " " + style(message, fg="red", bold=True))
+    logger.error(FAIL + " " + style(message, fg="red", bold=True))
 
 
 def warning(message):
-    echo(WARN + " " + style(message, fg="yellow", bold=True))
+    logger.warn(WARN + " " + style(message, fg="yellow", bold=True))
 
 
 def section(message):
-    echo(BUSY + " " + style(message, fg="magenta", bold=True))
+    logger.info(BUSY + " " + style(message, fg="magenta", bold=True))
 
 
 def general(message):
-    echo(STDS + " " + message)
+    logger.info(STDS + " " + message)


### PR DESCRIPTION
Fixes #16

The output logs look like the following and can be useful for tracking times of long-running operations.

```
[2023-10-10 11:03:47 +0530] [ BUSY ] Requesting for source namespace metadata...
[2023-10-10 11:03:48 +0530] [ PASS ] Source namespace metadata acquisition succeeded!
[2023-10-10 11:03:48 +0530]          Name: firmitas-notifier
[2023-10-10 11:03:48 +0530]          Identifier: 16511
[2023-10-10 11:03:48 +0530]          Maintainer: Akashdeep Dhar (ID t0xic0der)
[2023-10-10 11:03:48 +0530]          Location: https://pagure.io/firmitas-notifier
[2023-10-10 11:03:48 +0530]          Address: https://t0xic0der:XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX@pagure.io/firmitas-notifier.git
[2023-10-10 11:03:48 +0530]          Created on: Thu May 25 10:36:32 2023
[2023-10-10 11:03:48 +0530]          Last modified on: Thu May 25 10:36:32 2023
[2023-10-10 11:03:48 +0530]          Tags: []
[2023-10-10 11:03:49 +0530] [ BUSY ] Requesting for destination namespace metadata...
[2023-10-10 11:03:49 +0530] [ PASS ] Destination namespace metadata acquisition succeeded!
[2023-10-10 11:03:49 +0530]          Name: gridhead/protop2g-test
[2023-10-10 11:03:49 +0530]          Identifier: 42823949
[2023-10-10 11:03:49 +0530]          Maintainer: gridhead (ID Akashdeep Dhar)
[2023-10-10 11:03:49 +0530]          Location: https://gitlab.com/gridhead/protop2g-test
[2023-10-10 11:03:49 +0530]          Address: https://gridhead:XXXXXXXXXXXXXXXXXXXXXXXXXX@gitlab.com/gridhead/protop2g-test.git
[2023-10-10 11:03:49 +0530]          Created on: 2023-01-23T16:18:30.217Z
[2023-10-10 11:03:49 +0530]          Last modified on: 2023-10-10T05:16:32.087Z
[2023-10-10 11:03:49 +0530]          Tags: []
[2023-10-10 11:03:49 +0530] [ BUSY ] Attempting source namespace issue ticket count...
[2023-10-10 11:03:49 +0530] [ WARN ] Extracting all closed issue tickets with labels, with states and with comments off the given selection
[2023-10-10 11:03:51 +0530] [ BUSY ] Probing issue ticket #21...
[2023-10-10 11:03:51 +0530]          Skipping issue ticket as the issue ticket status does not match the provided status
[2023-10-10 11:03:51 +0530] [ PASS ] Namespace assets transferring queue processed!
[2023-10-10 11:03:51 +0530]          0 issue ticket(s) transferred
```